### PR TITLE
Allow interface names longer than 3 characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+ndp-proxy

--- a/ndp-proxy.c
+++ b/ndp-proxy.c
@@ -212,7 +212,7 @@ int main(int argc, char **argv)
 		err(1, "socket");
 
 	/* Bind to interface */
-	if ( setsockopt(sock, SOL_SOCKET, SO_BINDTODEVICE , interface, 3 ) < 0 )
+	if ( setsockopt(sock, SOL_SOCKET, SO_BINDTODEVICE , interface, strlen(interface) ) < 0 )
 		err(1, "bindtodevice");
 
 	/* Get interface MAC adress */


### PR DESCRIPTION
Hello, I found your ndp-proxy is very useful on a VPS I run docker on. The ndp proxy in linux isn't enough for me since the source address of the NDP packets have to be the target address and not a link local address. But ndp-proxy first didn't work on eth0 or other interface names with a length of more than three characters. It's is solved with this commit.