### PR TITLE
Fixed memcpy() length to fix the segmentation fault

### DIFF
--- a/ndp-proxy.c
+++ b/ndp-proxy.c
@@ -376,7 +376,7 @@ int forge_icmp6_na (unsigned char *buffer, unsigned char *srcmac, unsigned char 
 	} __attribute__((__packed__)) packet;
 
 	/* lla */
-	memcpy(&packet.na_opt_lla, lla, sizeof(struct in6_addr));
+	memcpy(&packet.na_opt_lla, lla, ETH_ALEN);
 
 	/* Neighbor Advertisement Option (source link layer address) */
 	packet.na_opt.nd_opt_type = 2;


### PR DESCRIPTION
Modified sizeof(struct in6_addr)` to ETH_ALEN in memcpy(&packet.na_opt_lla, lla, ETH_ALEN) to prevent segmentation fault caused after return from forge_icmp6_na method. I suspect it to be a possible stack corruption. 

I'm no expert in this, kindly feel free to correct me if am wrong :).